### PR TITLE
Build sequence diagram from trace

### DIFF
--- a/src/atlas/controllers/sequence_diagram.clj
+++ b/src/atlas/controllers/sequence_diagram.clj
@@ -1,0 +1,18 @@
+(ns atlas.controllers.sequence-diagram
+  (:require [atlas.domain.sequence-diagram :as d-sequence-diagram]
+            [common-clj.http-client.protocol :as hc-pro]))
+
+(defn- fetch-trace [trace-id http-client]
+  (-> http-client
+      (hc-pro/request :jaeger/get-trace {:path-params {:id trace-id}})
+      :body
+      :data
+      first))
+
+(defn get-sequence-diagram [trace-id {:keys [http-client]}]
+  (let [trace (fetch-trace trace-id http-client)]
+    {:start-time      (d-sequence-diagram/start-time trace)
+     :duration-ms     (d-sequence-diagram/duration-ms trace)
+     :lifelines       (d-sequence-diagram/lifelines trace)
+     :execution-boxes (d-sequence-diagram/execution-boxes trace)
+     :arrows          (d-sequence-diagram/arrows trace)}))

--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -1,0 +1,76 @@
+(ns atlas.domain.sequence-diagram
+  (:require [atlas.schemata.jaeger :as s-jaeger]
+            [atlas.schemata.sequence-diagram :as s-sequence-diagram]
+            [common-clj.schema.core :as cs]
+            [java-time :as time]
+            [schema.core :as s]))
+
+(defn- span->end-time [{:keys [start-time duration]}]
+  (let [start-epoch (time/instant (/ start-time 1000))]
+    (time/plus start-epoch (time/millis duration))))
+
+(defn- http-server? [{:keys [value]}] (= "server" value))
+
+(defn- http-client? [{:keys [value]}] (= "client" value))
+
+(defn- in-span? [{:keys [tags]}] (boolean (first (filter http-server? tags))))
+
+(defn- out-span? [{:keys [tags]}] (boolean (first (filter http-client? tags))))
+
+(defn- microseconds->epoch [microseconds] (time/instant (/ microseconds 1000)))
+
+(defn- span->service-name [{:keys [process-id]} trace]
+  (-> trace :processes process-id :service-name))
+
+(defn- span->execution-box [trace]
+  (fn [{:keys [span-id start-time duration] :as span}]
+    {:id          span-id
+     :start-time  (microseconds->epoch start-time)
+     :duration-ms duration
+     :lifeline    (span->service-name span trace)}))
+
+(defn- child-of? [{:keys [span-id]}]
+  (fn [{:keys [references]}]
+    (boolean (first (filter #(= span-id (:span-id %)) references)))))
+
+(defn- find-child [span trace]
+  (->> trace :spans (filter (child-of? span)) first))
+
+(defn- span->arrow-pair [trace]
+  (fn [acc out-span]
+    (if-let [child-span (find-child out-span trace)]
+      (conj acc
+            {:id         (:span-id out-span)
+             :from       (span->service-name out-span trace)
+             :to         (span->service-name child-span trace)
+             :start-time (microseconds->epoch (:start-time out-span))}
+            {:id         (:span-id child-span)
+             :from       (span->service-name child-span trace)
+             :to         (span->service-name out-span trace)
+             :start-time (span->end-time out-span)})
+      acc)))
+
+(s/defn start-time :- cs/EpochMillis
+  [trace :- s-jaeger/Trace]
+  (->> trace :spans (map :start-time) sort first microseconds->epoch))
+
+(s/defn duration-ms :- cs/PosInt
+  [trace :- s-jaeger/Trace]
+  (let [start-time (start-time trace)
+        end-time (->> trace :spans (map span->end-time) sort last)]
+    (.toMillis (time/duration start-time end-time))))
+
+(s/defn lifelines :- [s-sequence-diagram/Lifeline]
+  [trace :- s-jaeger/Trace]
+  (->> trace :processes (map (fn [[_ {:keys [service-name]}]]
+                               {:name service-name}))))
+
+(s/defn execution-boxes :- [s-sequence-diagram/ExecutionBox]
+  [trace :- s-jaeger/Trace]
+  (let [in-spans (->> trace :spans (filter in-span?))]
+    (map (span->execution-box trace) in-spans)))
+
+(s/defn arrows :- [s-sequence-diagram/Arrow]
+  [trace :- s-jaeger/Trace]
+  (let [out-spans (->> trace :spans (filter out-span?))]
+    (reduce (span->arrow-pair trace) [] out-spans)))

--- a/src/atlas/ports/http_server.clj
+++ b/src/atlas/ports/http_server.clj
@@ -1,9 +1,11 @@
 (ns atlas.ports.http-server
   (:require [atlas.controllers.operation :as c-operation]
+            [atlas.controllers.sequence-diagram :as c-sequence-diagram]
             [atlas.controllers.service :as c-service]
             [atlas.controllers.trace-graph :as c-trace-graph]
             [atlas.controllers.trace-search :as c-trace-search]
             [atlas.schemata.operation :as s-operation]
+            [atlas.schemata.sequence-diagram :as s-sequence-diagram]
             [atlas.schemata.service :as s-service]
             [atlas.schemata.trace-graph :as s-trace-graph]
             [atlas.schemata.trace-search :as s-trace-search]
@@ -49,7 +51,15 @@
     :path-params-schema {:id s/Str}
     :response-schema    s-trace-graph/TraceGraphResponse
     :handler            (fn [{{:keys [id]} :path-params} components]
-                          (ok {:graph (c-trace-graph/get-graph id components)}))}})
+                          (ok {:graph (c-trace-graph/get-graph id components)}))}
+
+   :route/get-sequence-diagram
+   {:path               "/api/traces/:id/sequence-diagram"
+    :method             :get
+    :path-params-schema {:id s/Str}
+    :response-schema    s-sequence-diagram/SequenceDiagramResponse
+    :handler            (fn [{{:keys [id]} :path-params} components]
+                          (ok {:sequence-diagram (c-sequence-diagram/get-sequence-diagram id components)}))}})
 
 ;; --- SERVER OVERRIDES ---
 (def server-overrides {})

--- a/src/atlas/schemata/jaeger.clj
+++ b/src/atlas/schemata/jaeger.clj
@@ -25,6 +25,11 @@
    :trace-id s/Str
    :span-id  s/Str})
 
+(def SpanTag
+  {:key   s/Str
+   :type  s/Str
+   :value s/Any})
+
 (def Span
   {:trace-id       s/Str
    :span-id        s/Str
@@ -32,7 +37,8 @@
    :operation-name s/Str
    :start-time     cs/TimestampMicroseconds
    :duration       s/Int
-   :references     [SpanReference]})
+   :references     [SpanReference]
+   :tags           [SpanTag]})
 
 (def TraceProcess
   {:service-name s/Str})

--- a/src/atlas/schemata/sequence_diagram.clj
+++ b/src/atlas/schemata/sequence_diagram.clj
@@ -1,0 +1,28 @@
+(ns atlas.schemata.sequence-diagram
+  (:require [common-clj.schema.core :as cs]
+            [schema.core :as s]))
+
+(def Lifeline
+  {:name s/Str})
+
+(def ExecutionBox
+  {:id          s/Str
+   :start-time  cs/EpochMillis
+   :duration-ms cs/PosInt
+   :lifeline    s/Str})
+
+(def Arrow
+  {:id         s/Str
+   :from       s/Str
+   :to         s/Str
+   :start-time cs/EpochMillis})
+
+(def SequenceDiagram
+  {:start-time      cs/EpochMillis
+   :duration-ms     cs/PosInt
+   :lifelines       [Lifeline]
+   :execution-boxes [ExecutionBox]
+   :arrows          [Arrow]})
+
+(def SequenceDiagramResponse
+  {:sequence-diagram SequenceDiagram})

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -1,0 +1,104 @@
+(ns atlas.domain.sequence-diagram-test
+  (:require [atlas.domain.sequence-diagram :as nut]
+            [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]))
+
+(def trace
+  {:trace-id "1"
+   :spans    [{:trace-id       "1"
+               :span-id        "1"
+               :process-id     :p1
+               :operation-name "http.in GET /api/orders/1"
+               :start-time     1500000000000000
+               :duration       1000
+               :references     []
+               :tags          [{:key   "span.kind"
+                                :type  "string"
+                                :value "server"}
+                               {:key   "http.method"
+                                :type  "string"
+                                :value "GET"}
+                               {:key   "http.url"
+                                :type  "string"
+                                :value "/api/orders/1"}]}
+
+              {:trace-id       "1"
+               :span-id        "2"
+               :process-id     :p1
+               :operation-name "http.out GET /api/orders/1"
+               :start-time     1500000000100000
+               :duration       300
+               :references     [{:ref-type :child-of
+                                 :trace-id "1"
+                                 :span-id  "1"}]
+               :tags          [{:key   "span.kind"
+                                :type  "string"
+                                :value "client"}
+                               {:key   "http.method"
+                                :type  "string"
+                                :value "GET"}
+                               {:key   "http.url"
+                                :type  "string"
+                                :value "/api/orders/1"}]}
+
+              {:trace-id       "1"
+               :span-id        "3"
+               :process-id     :p2
+               :operation-name "http.in GET /api/orders/1"
+               :start-time     1500000000200000
+               :duration       100
+               :references     [{:ref-type :child-of
+                                 :trace-id "1"
+                                 :span-id  "2"}]
+               :tags          [{:key   "span.kind"
+                                :type  "string"
+                                :value "server"}
+                               {:key   "http.method"
+                                :type  "string"
+                                :value "GET"}
+                               {:key   "http.url"
+                                :type  "string"
+                                :value "/api/orders/1"}]}]
+
+   :processes {:p1 {:service-name "bff"}
+               :p2 {:service-name "orders"}}})
+
+(deftest start-time
+  (testing "builds start-time from trace"
+    (is (= #epoch 1500000000000
+           (nut/start-time trace)))))
+
+(deftest duration-ms
+  (testing "builds duration from trace"
+    (is (= 1000
+           (nut/duration-ms trace)))))
+
+(deftest lifelines
+  (testing "builds lifelines from trace"
+    (is (= [{:name "bff"}
+            {:name "orders"}]
+           (nut/lifelines trace)))))
+
+(deftest execution-boxes
+  (testing "builds execution boxes from trace"
+    (is (= [{:id          "1"
+             :start-time  #epoch 1500000000000
+             :duration-ms 1000
+             :lifeline    "bff"}
+            {:id          "3"
+             :start-time  #epoch 1500000000200
+             :duration-ms 100
+             :lifeline    "orders"}]
+           (nut/execution-boxes trace)))))
+
+(deftest arrows
+  (testing "builds arrows from trace"
+    (is (= [{:id         "2"
+             :from       "bff"
+             :to         "orders"
+             :start-time #epoch 1500000000100}
+            {:id         "3"
+             :from       "orders"
+             :to         "bff"
+             :start-time #epoch 1500000000400}]
+           (nut/arrows trace)))))

--- a/test/atlas/domain/trace_graph_test.clj
+++ b/test/atlas/domain/trace_graph_test.clj
@@ -16,6 +16,7 @@
                                           :operation-name "http.out /api/orders"
                                           :start-time     1499999999999999
                                           :references     []
+                                          :tags           []
                                           :duration       1000}
                                          {:trace-id       "1"
                                           :span-id        "span-1-2"
@@ -25,6 +26,7 @@
                                           :references     [{:ref-type :child-of
                                                             :trace-id "1"
                                                             :span-id  "span-1-1"}]
+                                          :tags           []
                                           :duration       1001}]
                              :processes {:p1 {:service-name "frontend"}
                                          :p2 {:service-name "orders"}}})))))

--- a/test/atlas/domain/trace_search_test.clj
+++ b/test/atlas/domain/trace_search_test.clj
@@ -11,21 +11,24 @@
                 :operation-name "op-1-1"
                 :start-time     1500000000000000
                 :duration       1000
-                :references     []}
+                :references     []
+                :tags           []}
                {:trace-id       "trace-1"
                 :span-id        "span-1-2"
                 :process-id     :p2
                 :operation-name "op-1-2"
                 :start-time     1400000000000000
                 :duration       1001
-                :references     []}
+                :references     []
+                :tags           []}
                {:trace-id       "trace-3"
                 :span-id        "span-1-3"
                 :process-id     :p3
                 :operation-name "op-1-3"
                 :start-time     1450000000000000
                 :duration       1002
-                :references     []}]
+                :references     []
+                :tags           []}]
    :processes {:p1 {:service-name "orders"}
                :p2 {:service-name "feed"}
                :p3 {:service-name "orders"}}})

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -1,0 +1,93 @@
+(ns flows.get-sequence-diagram
+  (:require [common-clj.state-flow-helpers.http-client :as http-client]
+            [common-clj.state-flow-helpers.http-server :refer [GET]]
+            [flows.aux.init :refer [defflow]]
+            [state-flow.assertions.matcher-combinators :refer [match?]]))
+
+(def jaeger-response
+  {"data" [{"traceID" "1"
+            "spans"   [{"traceID"       "1"
+                        "spanID"        "1"
+                        "processID"     "p1"
+                        "operationName" "http.in GET /api/orders/1"
+                        "startTime"     1500000000000000
+                        "duration"      1000
+                        "references"    []
+                        "tags"          [{"key"   "span.kind"
+                                          "type"  "string"
+                                          "value" "server"}
+                                         {"key"   "http.method"
+                                          "type"  "string"
+                                          "value" "GET"}
+                                         {"key"   "http.url"
+                                          "type"  "string"
+                                          "value" "/api/orders/1"}]}
+
+                       {"traceID"       "1"
+                        "spanID"        "2"
+                        "processID"     "p1"
+                        "operationName" "http.out GET /api/orders/1"
+                        "startTime"     1500000000100000
+                        "duration"      300
+                        "references"    [{"ref-type" "CHILD_OF"
+                                          "traceID"  "1"
+                                          "spanID"   "1"}]
+                        "tags"          [{"key"   "span.kind"
+                                          "type"  "string"
+                                          "value" "client"}
+                                         {"key"   "http.method"
+                                          "type"  "string"
+                                          "value" "GET"}
+                                         {"key"   "http.url"
+                                          "type"  "string"
+                                          "value" "/api/orders/1"}]}
+
+                       {"traceID"       "1"
+                        "spanID"        "3"
+                        "processID"     "p2"
+                        "operationName" "http.in GET /api/orders/1"
+                        "startTime"     1500000000200000
+                        "duration"      100
+                        "references"    [{"ref-type" "CHILD_OF"
+                                          "traceID"  "1"
+                                          "spanID"   "2"}]
+                        "tags"          [{"key"   "span.kind"
+                                          "type"  "string"
+                                          "value" "server"}
+                                         {"key"   "http.method"
+                                          "type"  "string"
+                                          "value" "GET"}
+                                         {"key"   "http.url"
+                                          "type"  "string"
+                                          "value" "/api/orders/1"}]}]
+
+            "processes" {"p1" {"serviceName" "bff"}
+                         "p2" {"serviceName" "orders"}}}]})
+
+(defflow get-sequence-diagram
+  :pre-conditions [(http-client/mock! {"{{jaeger}}/api/traces/1" {:status 200
+                                                                  :body   jaeger-response}})]
+
+  (let [response (GET "/api/traces/1/sequence-diagram")]
+    (match? {:status 200
+             :body   {"sequence_diagram" {"start_time"      1500000000000
+                                          "duration_ms"     1000
+                                          "lifelines"       [{"name" "bff"}
+                                                             {"name" "orders"}]
+                                          "execution_boxes" [{"id"          "1"
+                                                              "start_time"  1500000000000
+                                                              "duration_ms" 1000
+                                                              "lifeline"    "bff"}
+                                                             {"id"          "3"
+                                                              "start_time"  1500000000200
+                                                              "duration_ms" 100
+                                                              "lifeline"    "orders"}]
+                                          "arrows"          [{"id"         "2"
+                                                              "from"       "bff"
+                                                              "to"         "orders"
+                                                              "start_time" 1500000000100}
+                                                             {"id"         "3"
+                                                              "from"       "orders"
+                                                              "to"         "bff"
+                                                              "start_time" 1500000000400}]}}}
+            response)))

--- a/test/flows/get_trace_graph.clj
+++ b/test/flows/get_trace_graph.clj
@@ -13,6 +13,7 @@
                           "operationName" "http.out /api/orders"
                           "startTime"     1499999999999999
                           "references"    []
+                          "tags"          []
                           "duration"      1000}
                          {"traceID"       "1"
                           "spanID"        "span-1-2"
@@ -22,6 +23,7 @@
                           "references"    [{"ref-type" "CHILD_OF"
                                             "trace-id" "1"
                                             "span-id"  "span-1-1"}]
+                          "tags"          []
                           "duration"      1001}]
             "processes" {"p1" {"serviceName" "frontend"}
                          "p2" {"serviceName" "orders"}}}]})

--- a/test/flows/search_trace.clj
+++ b/test/flows/search_trace.clj
@@ -20,14 +20,16 @@
                           "operationName" "op-1-1"
                           "startTime"     1500000000000000
                           "duration"      1000
-                          "references"    []}
+                          "references"    []
+                          "tags"          []}
                          {"traceID"       "trace-1"
                           "spanID"        "span-1-2"
                           "processID"     "p1"
                           "operationName" "op-1-2"
                           "startTime"     1499999999999999
                           "duration"      1001
-                          "references"    []}]
+                          "references"    []
+                          "tags"          []}]
             "processes" {"p1" {"serviceName" "orders"}}}
 
            {"traceID"   "trace-2"
@@ -37,14 +39,16 @@
                           "operation-name" "op-2-1"
                           "start-time"     1500000000000002
                           "duration"       1002
-                          "references"     []}
+                          "references"     []
+                          "tags"           []}
                          {"traceID"       "trace-2"
                           "spanID"        "span-2-2"
                           "processID"     "p2"
                           "operationName" "op-2-2"
                           "start-time"    1500000000000003
                           "duration"      1003
-                          "references"    []}]
+                          "references"    []
+                          "tags"          []}]
             "processes" {"p1" {"serviceName" "feed"}
                          "p2" {"serviceName" "orders"}}}]})
 


### PR DESCRIPTION
This commit creates a new endpoint `GET /api/traces/:trace-id/sequence-diagram` that fetches a trace from Jaeger and builds a sequence diagram from it. This implementation is based on the following assumptions:
- Every span has a tag `span.kind` that allow us to identify if it is a client or a server (more info at https://opentracing.io/specification/conventions/);
- Each trace process should become a lifeline;
- Server spans should become execution boxes on the sequence diagram;
- Client spans should become two arrows (in and out) in the sequence diagram';

This is a very basic implementation and only supports two kinds of span - `client` and `server`. In a future commit we should add support for others kinds of span, like `consumer` and `producer`.

Co-authored-by: Davi Correia Jr <davicorreiajr@gmail.com>
Co-authored-by: Pedro Darvas <pedro.darvas@usp.br>