### PR TITLE
Add label and prefix to arrow

### DIFF
--- a/src/atlas/schemata/sequence_diagram.clj
+++ b/src/atlas/schemata/sequence_diagram.clj
@@ -12,10 +12,12 @@
    :lifeline    s/Str})
 
 (def Arrow
-  {:id         s/Str
-   :from       s/Str
-   :to         s/Str
-   :start-time cs/EpochMillis})
+  {:id                      s/Str
+   :from                    s/Str
+   :to                      s/Str
+   :start-time              cs/EpochMillis
+   (s/optional-key :prefix) s/Str
+   :label                   s/Str})
 
 (def SequenceDiagram
   {:start-time      cs/EpochMillis

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -96,9 +96,12 @@
     (is (= [{:id         "2"
              :from       "bff"
              :to         "orders"
-             :start-time #epoch 1500000000100}
+             :start-time #epoch 1500000000100
+             :prefix     "GET"
+             :label      "/api/orders/1"}
             {:id         "3"
              :from       "orders"
              :to         "bff"
-             :start-time #epoch 1500000000400}]
+             :start-time #epoch 1500000000400
+             :label      "response"}]
            (nut/arrows trace)))))

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -85,9 +85,12 @@
                                           "arrows"          [{"id"         "2"
                                                               "from"       "bff"
                                                               "to"         "orders"
-                                                              "start_time" 1500000000100}
+                                                              "start_time" 1500000000100
+                                                              "prefix"     "GET"
+                                                              "label"      "/api/orders/1"}
                                                              {"id"         "3"
                                                               "from"       "orders"
                                                               "to"         "bff"
-                                                              "start_time" 1500000000400}]}}}
+                                                              "start_time" 1500000000400
+                                                              "label"      "response"}]}}}
             response)))


### PR DESCRIPTION
This commit adds label and prefix to http arrows. We're following these rules:

- http outgoing arrow -> prefix is the http method and label is the http url
- http response arrow -> prefix is not present, label is "response"

Co-authored-by: Davi Correia Jr <davicorreiajr@gmail.com>