### PR TITLE
Create lifelines from kafka topics

### DIFF
--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -58,7 +58,22 @@
                                 :value "GET"}
                                {:key   "http.url"
                                 :type  "string"
-                                :value "/api/orders/1"}]}]
+                                :value "/api/orders/1"}]}
+              {:trace-id       "1"
+               :span-id        "4"
+               :process-id     :p2
+               :operation-name "kafka.out PROCESS_ORDER"
+               :start-time     1500000000250000
+               :duration      50
+               :references    [{:ref-type :child-of
+                                :trace-id "1"
+                                :span-id  "3"}]
+               :tags          [{:key   "span.kind"
+                                :type  "string"
+                                :value "producer"}
+                               {:key   "message_bus.destination"
+                                :type  "string"
+                                :value "PROCESS_ORDER"}]}]
 
    :processes {:p1 {:service-name "bff"}
                :p2 {:service-name "orders"}}})
@@ -76,7 +91,8 @@
 (deftest lifelines
   (testing "builds lifelines from trace"
     (is (= [{:name "bff"}
-            {:name "orders"}]
+            {:name "orders"}
+            {:name "PROCESS_ORDER"}]
            (nut/lifelines trace)))))
 
 (deftest execution-boxes

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -59,7 +59,22 @@
                                           "value" "GET"}
                                          {"key"   "http.url"
                                           "type"  "string"
-                                          "value" "/api/orders/1"}]}]
+                                          "value" "/api/orders/1"}]}
+                       {"traceID"       "1"
+                        "spanID"        "4"
+                        "processID"     "p2"
+                        "operationName" "kafka.out PROCESS_ORDER"
+                        "startTime"     1500000000250000
+                        "duration"      50
+                        "references"    [{"ref-type" "CHILD_OF"
+                                          "traceID"  "1"
+                                          "spanID"   "3"}]
+                        "tags"          [{"key"   "span.kind"
+                                          "type"  "string"
+                                          "value" "producer"}
+                                         {"key"   "message_bus.destination"
+                                          "type"  "string"
+                                          "value" "PROCESS_ORDER"}]}]
 
             "processes" {"p1" {"serviceName" "bff"}
                          "p2" {"serviceName" "orders"}}}]})
@@ -73,7 +88,8 @@
              :body   {"sequence_diagram" {"start_time"      1500000000000
                                           "duration_ms"     1000
                                           "lifelines"       [{"name" "bff"}
-                                                             {"name" "orders"}]
+                                                             {"name" "orders"}
+                                                             {"name" "PROCESS_ORDER"}]
                                           "execution_boxes" [{"id"          "1"
                                                               "start_time"  1500000000000
                                                               "duration_ms" 1000


### PR DESCRIPTION
Now we also create lifelines from kafka topics. Our assumptions are:

- the lifelines are created only from `producers` (i.e. the spans which contain a tag whose key is `span.kind` and its value is `producer`)
- we expect the respective span to also contain a tag whose `key` is `message_bus.destination`.