### PR TITLE
Create execution boxes for consumer spans

### DIFF
--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -23,6 +23,8 @@
 
 (defn- server-span? [{:keys [tags]}] (has-tag? "span.kind" "server" tags))
 
+(defn- consumer-span? [{:keys [tags]}] (has-tag? "span.kind" "consumer" tags))
+
 (defn- client-span? [{:keys [tags]}] (has-tag? "span.kind" "client" tags))
 
 (defn- producer-span? [{:keys [tags]}] (has-tag? "span.kind" "producer" tags))
@@ -88,8 +90,9 @@
 
 (s/defn execution-boxes :- [s-sequence-diagram/ExecutionBox]
   [trace :- s-jaeger/Trace]
-  (let [server-spans (->> trace :spans (filter server-span?))]
-    (map (span->execution-box trace) server-spans)))
+  (let [server-spans (->> trace :spans (filter server-span?))
+        consumer-spans (->> trace :spans (filter consumer-span?))]
+    (map (span->execution-box trace) (concat server-spans consumer-spans))))
 
 (s/defn arrows :- [s-sequence-diagram/Arrow]
   [trace :- s-jaeger/Trace]

--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -19,7 +19,7 @@
   ([k tags] (->> tags (filter (match-tag? k)) first))
   ([k v tags] (->> tags (filter (match-tag? k v)) first)))
 
-(def has-tag?  (comp boolean find-tag))
+(def has-tag? (comp boolean find-tag))
 
 (defn- server-span? [{:keys [tags]}] (has-tag? "span.kind" "server" tags))
 
@@ -79,18 +79,18 @@
 (s/defn duration-ms :- cs/PosInt
   [trace :- s-jaeger/Trace]
   (let [start-time (start-time trace)
-        end-time (->> trace :spans (map span->end-time) sort last)]
+        end-time   (->> trace :spans (map span->end-time) sort last)]
     (.toMillis (time/duration start-time end-time))))
 
 (s/defn lifelines :- [s-sequence-diagram/Lifeline]
-  [trace :- s-jaeger/Trace]
-  (let [services (->> trace :processes (map process->lifeline))
-        topics (->> trace :spans (filter producer-span?) (map span->topic) (map topic->lifeline))]
+  [{:keys [spans processes]} :- s-jaeger/Trace]
+  (let [services (->> processes (map process->lifeline))
+        topics   (->> spans (filter producer-span?) (map span->topic) (map topic->lifeline))]
     (concat services topics)))
 
 (s/defn execution-boxes :- [s-sequence-diagram/ExecutionBox]
   [trace :- s-jaeger/Trace]
-  (let [server-spans (->> trace :spans (filter server-span?))
+  (let [server-spans   (->> trace :spans (filter server-span?))
         consumer-spans (->> trace :spans (filter consumer-span?))]
     (map (span->execution-box trace) (concat server-spans consumer-spans))))
 

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -12,15 +12,15 @@
                :start-time     1500000000000000
                :duration       1000
                :references     []
-               :tags          [{:key   "span.kind"
-                                :type  "string"
-                                :value "server"}
-                               {:key   "http.method"
-                                :type  "string"
-                                :value "GET"}
-                               {:key   "http.url"
-                                :type  "string"
-                                :value "/api/orders/1"}]}
+               :tags           [{:key   "span.kind"
+                                 :type  "string"
+                                 :value "server"}
+                                {:key   "http.method"
+                                 :type  "string"
+                                 :value "GET"}
+                                {:key   "http.url"
+                                 :type  "string"
+                                 :value "/api/orders/1"}]}
 
               {:trace-id       "1"
                :span-id        "2"
@@ -31,15 +31,15 @@
                :references     [{:ref-type :child-of
                                  :trace-id "1"
                                  :span-id  "1"}]
-               :tags          [{:key   "span.kind"
-                                :type  "string"
-                                :value "client"}
-                               {:key   "http.method"
-                                :type  "string"
-                                :value "GET"}
-                               {:key   "http.url"
-                                :type  "string"
-                                :value "/api/orders/1"}]}
+               :tags           [{:key   "span.kind"
+                                 :type  "string"
+                                 :value "client"}
+                                {:key   "http.method"
+                                 :type  "string"
+                                 :value "GET"}
+                                {:key   "http.url"
+                                 :type  "string"
+                                 :value "/api/orders/1"}]}
 
               {:trace-id       "1"
                :span-id        "3"
@@ -50,45 +50,45 @@
                :references     [{:ref-type :child-of
                                  :trace-id "1"
                                  :span-id  "2"}]
-               :tags          [{:key   "span.kind"
-                                :type  "string"
-                                :value "server"}
-                               {:key   "http.method"
-                                :type  "string"
-                                :value "GET"}
-                               {:key   "http.url"
-                                :type  "string"
-                                :value "/api/orders/1"}]}
+               :tags           [{:key   "span.kind"
+                                 :type  "string"
+                                 :value "server"}
+                                {:key   "http.method"
+                                 :type  "string"
+                                 :value "GET"}
+                                {:key   "http.url"
+                                 :type  "string"
+                                 :value "/api/orders/1"}]}
               {:trace-id       "1"
                :span-id        "4"
                :process-id     :p2
                :operation-name "kafka.out PROCESS_ORDER"
                :start-time     1500000000250000
-               :duration      50
-               :references    [{:ref-type :child-of
-                                :trace-id "1"
-                                :span-id  "3"}]
-               :tags          [{:key   "span.kind"
-                                :type  "string"
-                                :value "producer"}
-                               {:key   "message_bus.destination"
-                                :type  "string"
-                                :value "PROCESS_ORDER"}]}
+               :duration       50
+               :references     [{:ref-type :child-of
+                                 :trace-id "1"
+                                 :span-id  "3"}]
+               :tags           [{:key   "span.kind"
+                                 :type  "string"
+                                 :value "producer"}
+                                {:key   "message_bus.destination"
+                                 :type  "string"
+                                 :value "PROCESS_ORDER"}]}
               {:trace-id       "1"
                :span-id        "5"
                :process-id     :p2
                :operation-name "kafka.in PROCESS_ORDER"
                :start-time     1500000000350000
-               :duration      50
-               :references    [{:ref-type :child-of
-                                :trace-id "1"
-                                :span-id  "4"}]
-               :tags          [{:key   "span.kind"
-                                :type  "string"
-                                :value "consumer"}
-                               {:key   "message_bus.destination"
-                                :type  "string"
-                                :value "PROCESS_ORDER"}]}]
+               :duration       50
+               :references     [{:ref-type :child-of
+                                 :trace-id "1"
+                                 :span-id  "4"}]
+               :tags           [{:key   "span.kind"
+                                 :type  "string"
+                                 :value "consumer"}
+                                {:key   "message_bus.destination"
+                                 :type  "string"
+                                 :value "PROCESS_ORDER"}]}]
 
    :processes {:p1 {:service-name "bff"}
                :p2 {:service-name "orders"}}})

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -73,6 +73,21 @@
                                 :value "producer"}
                                {:key   "message_bus.destination"
                                 :type  "string"
+                                :value "PROCESS_ORDER"}]}
+              {:trace-id       "1"
+               :span-id        "5"
+               :process-id     :p2
+               :operation-name "kafka.in PROCESS_ORDER"
+               :start-time     1500000000350000
+               :duration      50
+               :references    [{:ref-type :child-of
+                                :trace-id "1"
+                                :span-id  "4"}]
+               :tags          [{:key   "span.kind"
+                                :type  "string"
+                                :value "consumer"}
+                               {:key   "message_bus.destination"
+                                :type  "string"
                                 :value "PROCESS_ORDER"}]}]
 
    :processes {:p1 {:service-name "bff"}
@@ -104,6 +119,10 @@
             {:id          "3"
              :start-time  #epoch 1500000000200
              :duration-ms 100
+             :lifeline    "orders"}
+            {:id          "5"
+             :start-time  #epoch 1500000000350
+             :duration-ms 50
              :lifeline    "orders"}]
            (nut/execution-boxes trace)))))
 

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -74,6 +74,21 @@
                                           "value" "producer"}
                                          {"key"   "message_bus.destination"
                                           "type"  "string"
+                                          "value" "PROCESS_ORDER"}]}
+                       {"traceID"       "1"
+                        "spanID"        "5"
+                        "processID"     "p2"
+                        "operationName" "kafka.in PROCESS_ORDER"
+                        "startTime"     1500000000350000
+                        "duration"      50
+                        "references"    [{"ref-type" "CHILD_OF"
+                                          "traceID"  "1"
+                                          "spanID"   "4"}]
+                        "tags"          [{"key"   "span.kind"
+                                          "type"  "string"
+                                          "value" "consumer"}
+                                         {"key"   "message_bus.destination"
+                                          "type"  "string"
                                           "value" "PROCESS_ORDER"}]}]
 
             "processes" {"p1" {"serviceName" "bff"}
@@ -97,6 +112,10 @@
                                                              {"id"          "3"
                                                               "start_time"  1500000000200
                                                               "duration_ms" 100
+                                                              "lifeline"    "orders"}
+                                                             {"id"          "5"
+                                                              "start_time"  1500000000350
+                                                              "duration_ms" 50
                                                               "lifeline"    "orders"}]
                                           "arrows"          [{"id"         "2"
                                                               "from"       "bff"


### PR DESCRIPTION
We assume the span will have a tag whose tag is `span.kind` and value `consumer`.