### PR TITLE
Add arrows for asynchronous operations (i.e. produce and consume)

### DIFF
--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -72,6 +72,24 @@
              :label      "response"})
       acc)))
 
+(defn- producer-span->arrow [trace]
+  (fn [acc producer-span]
+    (conj acc
+          {:id (:span-id producer-span)
+           :from (span->service-name producer-span trace)
+           :to (span->topic producer-span)
+           :start-time (microseconds->epoch (:start-time producer-span))
+           :label "produce"})))
+
+(defn- consumer-span->arrow [trace]
+  (fn [acc consumer-span]
+    (conj acc
+          {:id (:span-id consumer-span)
+           :from (span->topic consumer-span)
+           :to (span->service-name consumer-span trace)
+           :start-time (microseconds->epoch (:start-time consumer-span))
+           :label "consume"})))
+
 (s/defn start-time :- cs/EpochMillis
   [trace :- s-jaeger/Trace]
   (->> trace :spans (map :start-time) sort first microseconds->epoch))
@@ -96,5 +114,19 @@
 
 (s/defn arrows :- [s-sequence-diagram/Arrow]
   [trace :- s-jaeger/Trace]
-  (let [client-spans (->> trace :spans (filter client-span?))]
-    (reduce (span->arrow-pair trace) [] client-spans)))
+  (let [client-span-arrows (->> trace
+                                :spans
+                                (filter client-span?)
+                                (reduce (span->arrow-pair trace) []))
+        producer-arrows (->> trace
+                             :spans
+                             (filter producer-span?)
+                             (reduce (producer-span->arrow trace) []))
+        consumer-arrows (->> trace
+                             :spans
+                             (filter consumer-span?)
+                             (reduce (consumer-span->arrow trace) []))]
+    (concat
+     client-span-arrows
+     producer-arrows
+     consumer-arrows)))

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -138,5 +138,15 @@
              :from       "orders"
              :to         "bff"
              :start-time #epoch 1500000000400
-             :label      "response"}]
+             :label      "response"}
+            {:id         "4"
+             :from       "orders"
+             :to         "PROCESS_ORDER"
+             :start-time #epoch 1500000000250
+             :label      "produce"}
+            {:id         "5"
+             :from       "PROCESS_ORDER"
+             :to         "orders"
+             :start-time #epoch 1500000000350
+             :label      "consume"}]
            (nut/arrows trace)))))

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -127,5 +127,15 @@
                                                               "from"       "orders"
                                                               "to"         "bff"
                                                               "start_time" 1500000000400
-                                                              "label"      "response"}]}}}
+                                                              "label"      "response"}
+                                                             {"id"         "4"
+                                                              "from"       "orders"
+                                                              "to"         "PROCESS_ORDER"
+                                                              "start_time" 1500000000250
+                                                              "label"      "produce"}
+                                                             {"id"         "5"
+                                                              "from"       "PROCESS_ORDER"
+                                                              "to"         "orders"
+                                                              "start_time" 1500000000350
+                                                              "label"      "consume"}]}}}
             response)))


### PR DESCRIPTION
Our assumptions for `produce` arrows:
- we first get the `producer` spans, ie spans that contain a tag where the `key` is `span.kind` and `value` is `producer`;
- the arrows are then built like this:
  - id: id from the span
  - from: span service span (which is the name of the process associated to it)
  - to: the topic produced by the span
  - start-time: the respective span start-time
  - label: "produce"

Our assumptions for `consumer` arrows:
- we first get the `consumer` spans, ie spans that contain a tag where the `key` is `span.kind` and `value` is `consumer`;
- the arrows are then built like this:
  - id: id from the span
  - from: the topic consumed by the span
  - to: span service span (which is the name of the process associated to it)
  - start-time: the respective span start-time
  - label: "consume"

Recalling: the topic name comes from the tag value, whose key is `message_bus.destination`.