### PR TITLE
Fork cljfmt linter so we get vertical alignment on maps and bindings

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -5,8 +5,8 @@
             [common-clj.config.in-memory-config :as imc]))
 
 (def config
-  {:app-name  :atlas
-   :http-port 9000
+  {:app-name    :atlas
+   :http-port   9000
    :known-hosts {:jaeger "https://prod-jaeger.nubank.com.br"}})
 
 (def dev-system

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                       [com.stuartsierra/component.repl "0.2.0"]
                                       [clj-kondo "2020.02.28-1"]]
                        :source-paths ["dev"]
-                       :plugins [[lein-cljfmt "0.6.6"]
+                       :plugins [[lucasmafra/lein-cljfmt "0.5.5"]
                                  [lein-kibit "0.1.8"]
                                  [lein-nsorg "0.3.0"]
                                  [clj-kondo "2020.02.28-1"]]

--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -84,7 +84,7 @@
 
 (s/defn lifelines :- [s-sequence-diagram/Lifeline]
   [{:keys [spans processes]} :- s-jaeger/Trace]
-  (let [services (->> processes (map process->lifeline))
+  (let [services (map process->lifeline processes)
         topics   (->> spans (filter producer-span?) (map span->topic) (map topic->lifeline))]
     (concat services topics)))
 

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -4,91 +4,91 @@
             [common-clj.clojure-test-helpers.core :refer [deftest]]))
 
 (def trace
-  {:trace-id "1"
-   :spans    [{:trace-id       "1"
-               :span-id        "1"
-               :process-id     :p1
-               :operation-name "http.in GET /api/orders/1"
-               :start-time     1500000000000000
-               :duration       1000
-               :references     []
-               :tags           [{:key   "span.kind"
-                                 :type  "string"
-                                 :value "server"}
-                                {:key   "http.method"
-                                 :type  "string"
-                                 :value "GET"}
-                                {:key   "http.url"
-                                 :type  "string"
-                                 :value "/api/orders/1"}]}
+  {:trace-id  "1"
+   :spans     [{:trace-id       "1"
+                :span-id        "1"
+                :process-id     :p1
+                :operation-name "http.in GET /api/orders/1"
+                :start-time     1500000000000000
+                :duration       1000
+                :references     []
+                :tags           [{:key   "span.kind"
+                                  :type  "string"
+                                  :value "server"}
+                                 {:key   "http.method"
+                                  :type  "string"
+                                  :value "GET"}
+                                 {:key   "http.url"
+                                  :type  "string"
+                                  :value "/api/orders/1"}]}
 
-              {:trace-id       "1"
-               :span-id        "2"
-               :process-id     :p1
-               :operation-name "http.out GET /api/orders/1"
-               :start-time     1500000000100000
-               :duration       300
-               :references     [{:ref-type :child-of
-                                 :trace-id "1"
-                                 :span-id  "1"}]
-               :tags           [{:key   "span.kind"
-                                 :type  "string"
-                                 :value "client"}
-                                {:key   "http.method"
-                                 :type  "string"
-                                 :value "GET"}
-                                {:key   "http.url"
-                                 :type  "string"
-                                 :value "/api/orders/1"}]}
+               {:trace-id       "1"
+                :span-id        "2"
+                :process-id     :p1
+                :operation-name "http.out GET /api/orders/1"
+                :start-time     1500000000100000
+                :duration       300
+                :references     [{:ref-type :child-of
+                                  :trace-id "1"
+                                  :span-id  "1"}]
+                :tags           [{:key   "span.kind"
+                                  :type  "string"
+                                  :value "client"}
+                                 {:key   "http.method"
+                                  :type  "string"
+                                  :value "GET"}
+                                 {:key   "http.url"
+                                  :type  "string"
+                                  :value "/api/orders/1"}]}
 
-              {:trace-id       "1"
-               :span-id        "3"
-               :process-id     :p2
-               :operation-name "http.in GET /api/orders/1"
-               :start-time     1500000000200000
-               :duration       100
-               :references     [{:ref-type :child-of
-                                 :trace-id "1"
-                                 :span-id  "2"}]
-               :tags           [{:key   "span.kind"
-                                 :type  "string"
-                                 :value "server"}
-                                {:key   "http.method"
-                                 :type  "string"
-                                 :value "GET"}
-                                {:key   "http.url"
-                                 :type  "string"
-                                 :value "/api/orders/1"}]}
-              {:trace-id       "1"
-               :span-id        "4"
-               :process-id     :p2
-               :operation-name "kafka.out PROCESS_ORDER"
-               :start-time     1500000000250000
-               :duration       50
-               :references     [{:ref-type :child-of
-                                 :trace-id "1"
-                                 :span-id  "3"}]
-               :tags           [{:key   "span.kind"
-                                 :type  "string"
-                                 :value "producer"}
-                                {:key   "message_bus.destination"
-                                 :type  "string"
-                                 :value "PROCESS_ORDER"}]}
-              {:trace-id       "1"
-               :span-id        "5"
-               :process-id     :p2
-               :operation-name "kafka.in PROCESS_ORDER"
-               :start-time     1500000000350000
-               :duration       50
-               :references     [{:ref-type :child-of
-                                 :trace-id "1"
-                                 :span-id  "4"}]
-               :tags           [{:key   "span.kind"
-                                 :type  "string"
-                                 :value "consumer"}
-                                {:key   "message_bus.destination"
-                                 :type  "string"
-                                 :value "PROCESS_ORDER"}]}]
+               {:trace-id       "1"
+                :span-id        "3"
+                :process-id     :p2
+                :operation-name "http.in GET /api/orders/1"
+                :start-time     1500000000200000
+                :duration       100
+                :references     [{:ref-type :child-of
+                                  :trace-id "1"
+                                  :span-id  "2"}]
+                :tags           [{:key   "span.kind"
+                                  :type  "string"
+                                  :value "server"}
+                                 {:key   "http.method"
+                                  :type  "string"
+                                  :value "GET"}
+                                 {:key   "http.url"
+                                  :type  "string"
+                                  :value "/api/orders/1"}]}
+               {:trace-id       "1"
+                :span-id        "4"
+                :process-id     :p2
+                :operation-name "kafka.out PROCESS_ORDER"
+                :start-time     1500000000250000
+                :duration       50
+                :references     [{:ref-type :child-of
+                                  :trace-id "1"
+                                  :span-id  "3"}]
+                :tags           [{:key   "span.kind"
+                                  :type  "string"
+                                  :value "producer"}
+                                 {:key   "message_bus.destination"
+                                  :type  "string"
+                                  :value "PROCESS_ORDER"}]}
+               {:trace-id       "1"
+                :span-id        "5"
+                :process-id     :p2
+                :operation-name "kafka.in PROCESS_ORDER"
+                :start-time     1500000000350000
+                :duration       50
+                :references     [{:ref-type :child-of
+                                  :trace-id "1"
+                                  :span-id  "4"}]
+                :tags           [{:key   "span.kind"
+                                  :type  "string"
+                                  :value "consumer"}
+                                 {:key   "message_bus.destination"
+                                  :type  "string"
+                                  :value "PROCESS_ORDER"}]}]
 
    :processes {:p1 {:service-name "bff"}
                :p2 {:service-name "orders"}}})

--- a/test/flows/aux/init.clj
+++ b/test/flows/aux/init.clj
@@ -27,6 +27,6 @@
                                  [(second forms) (rest (rest forms))]
                                  [[] forms])]
     `(state-flow.cljtest/defflow ~name {:runner run!*
-                                        :init #(init! {})}
+                                        :init   #(init! {})}
        ~@pre-conditions
        ~@flows)))

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -5,91 +5,91 @@
             [state-flow.assertions.matcher-combinators :refer [match?]]))
 
 (def jaeger-response
-  {"data" [{"traceID" "1"
-            "spans"   [{"traceID"       "1"
-                        "spanID"        "1"
-                        "processID"     "p1"
-                        "operationName" "http.in GET /api/orders/1"
-                        "startTime"     1500000000000000
-                        "duration"      1000
-                        "references"    []
-                        "tags"          [{"key"   "span.kind"
-                                          "type"  "string"
-                                          "value" "server"}
-                                         {"key"   "http.method"
-                                          "type"  "string"
-                                          "value" "GET"}
-                                         {"key"   "http.url"
-                                          "type"  "string"
-                                          "value" "/api/orders/1"}]}
+  {"data" [{"traceID"   "1"
+            "spans"     [{"traceID"       "1"
+                          "spanID"        "1"
+                          "processID"     "p1"
+                          "operationName" "http.in GET /api/orders/1"
+                          "startTime"     1500000000000000
+                          "duration"      1000
+                          "references"    []
+                          "tags"          [{"key"   "span.kind"
+                                            "type"  "string"
+                                            "value" "server"}
+                                           {"key"   "http.method"
+                                            "type"  "string"
+                                            "value" "GET"}
+                                           {"key"   "http.url"
+                                            "type"  "string"
+                                            "value" "/api/orders/1"}]}
 
-                       {"traceID"       "1"
-                        "spanID"        "2"
-                        "processID"     "p1"
-                        "operationName" "http.out GET /api/orders/1"
-                        "startTime"     1500000000100000
-                        "duration"      300
-                        "references"    [{"ref-type" "CHILD_OF"
-                                          "traceID"  "1"
-                                          "spanID"   "1"}]
-                        "tags"          [{"key"   "span.kind"
-                                          "type"  "string"
-                                          "value" "client"}
-                                         {"key"   "http.method"
-                                          "type"  "string"
-                                          "value" "GET"}
-                                         {"key"   "http.url"
-                                          "type"  "string"
-                                          "value" "/api/orders/1"}]}
+                         {"traceID"       "1"
+                          "spanID"        "2"
+                          "processID"     "p1"
+                          "operationName" "http.out GET /api/orders/1"
+                          "startTime"     1500000000100000
+                          "duration"      300
+                          "references"    [{"ref-type" "CHILD_OF"
+                                            "traceID"  "1"
+                                            "spanID"   "1"}]
+                          "tags"          [{"key"   "span.kind"
+                                            "type"  "string"
+                                            "value" "client"}
+                                           {"key"   "http.method"
+                                            "type"  "string"
+                                            "value" "GET"}
+                                           {"key"   "http.url"
+                                            "type"  "string"
+                                            "value" "/api/orders/1"}]}
 
-                       {"traceID"       "1"
-                        "spanID"        "3"
-                        "processID"     "p2"
-                        "operationName" "http.in GET /api/orders/1"
-                        "startTime"     1500000000200000
-                        "duration"      100
-                        "references"    [{"ref-type" "CHILD_OF"
-                                          "traceID"  "1"
-                                          "spanID"   "2"}]
-                        "tags"          [{"key"   "span.kind"
-                                          "type"  "string"
-                                          "value" "server"}
-                                         {"key"   "http.method"
-                                          "type"  "string"
-                                          "value" "GET"}
-                                         {"key"   "http.url"
-                                          "type"  "string"
-                                          "value" "/api/orders/1"}]}
-                       {"traceID"       "1"
-                        "spanID"        "4"
-                        "processID"     "p2"
-                        "operationName" "kafka.out PROCESS_ORDER"
-                        "startTime"     1500000000250000
-                        "duration"      50
-                        "references"    [{"ref-type" "CHILD_OF"
-                                          "traceID"  "1"
-                                          "spanID"   "3"}]
-                        "tags"          [{"key"   "span.kind"
-                                          "type"  "string"
-                                          "value" "producer"}
-                                         {"key"   "message_bus.destination"
-                                          "type"  "string"
-                                          "value" "PROCESS_ORDER"}]}
-                       {"traceID"       "1"
-                        "spanID"        "5"
-                        "processID"     "p2"
-                        "operationName" "kafka.in PROCESS_ORDER"
-                        "startTime"     1500000000350000
-                        "duration"      50
-                        "references"    [{"ref-type" "CHILD_OF"
-                                          "traceID"  "1"
-                                          "spanID"   "4"}]
-                        "tags"          [{"key"   "span.kind"
-                                          "type"  "string"
-                                          "value" "consumer"}
-                                         {"key"   "message_bus.destination"
-                                          "type"  "string"
-                                          "value" "PROCESS_ORDER"}]}]
+                         {"traceID"       "1"
+                          "spanID"        "3"
+                          "processID"     "p2"
+                          "operationName" "http.in GET /api/orders/1"
+                          "startTime"     1500000000200000
+                          "duration"      100
+                          "references"    [{"ref-type" "CHILD_OF"
+                                            "traceID"  "1"
+                                            "spanID"   "2"}]
+                          "tags"          [{"key"   "span.kind"
+                                            "type"  "string"
+                                            "value" "server"}
+                                           {"key"   "http.method"
+                                            "type"  "string"
+                                            "value" "GET"}
+                                           {"key"   "http.url"
+                                            "type"  "string"
+                                            "value" "/api/orders/1"}]}
+                         {"traceID"       "1"
+                          "spanID"        "4"
+                          "processID"     "p2"
+                          "operationName" "kafka.out PROCESS_ORDER"
+                          "startTime"     1500000000250000
+                          "duration"      50
+                          "references"    [{"ref-type" "CHILD_OF"
+                                            "traceID"  "1"
+                                            "spanID"   "3"}]
+                          "tags"          [{"key"   "span.kind"
+                                            "type"  "string"
+                                            "value" "producer"}
+                                           {"key"   "message_bus.destination"
+                                            "type"  "string"
+                                            "value" "PROCESS_ORDER"}]}
+                         {"traceID"       "1"
+                          "spanID"        "5"
+                          "processID"     "p2"
+                          "operationName" "kafka.in PROCESS_ORDER"
+                          "startTime"     1500000000350000
+                          "duration"      50
+                          "references"    [{"ref-type" "CHILD_OF"
+                                            "traceID"  "1"
+                                            "spanID"   "4"}]
+                          "tags"          [{"key"   "span.kind"
+                                            "type"  "string"
+                                            "value" "consumer"}
+                                           {"key"   "message_bus.destination"
+                                            "type"  "string"
+                                            "value" "PROCESS_ORDER"}]}]
 
             "processes" {"p1" {"serviceName" "bff"}
                          "p2" {"serviceName" "orders"}}}]})

--- a/test/flows/get_trace_graph.clj
+++ b/test/flows/get_trace_graph.clj
@@ -37,8 +37,8 @@
   [response (GET "/api/traces/1/graph")]
 
   (match? {:status 200
-           :body {"graph" {"nodes" (m/in-any-order [{"service" "frontend"}
-                                                    {"service" "orders"}])
-                           "edges" [{"from" "frontend"
-                                     "to"   "orders"}]}}}
+           :body   {"graph" {"nodes" (m/in-any-order [{"service" "frontend"}
+                                                      {"service" "orders"}])
+                             "edges" [{"from" "frontend"
+                                       "to"   "orders"}]}}}
           response))

--- a/test/flows/search_trace.clj
+++ b/test/flows/search_trace.clj
@@ -63,19 +63,19 @@
                                                     "end=1582769681000"))]
 
   (match? {:status 200
-           :body {"traces" [{"trace_id"    "trace-1"
-                             "total_spans" 2
-                             "duration_ms" 2001
-                             "start_time"  1499999999999
-                             "services"    [{"name"            "orders"
-                                             "number_of_spans" 2}]}
+           :body   {"traces" [{"trace_id"    "trace-1"
+                               "total_spans" 2
+                               "duration_ms" 2001
+                               "start_time"  1499999999999
+                               "services"    [{"name"            "orders"
+                                               "number_of_spans" 2}]}
 
-                            {"trace_id"    "trace-2"
-                             "total_spans" 2
-                             "duration_ms" 2005
-                             "start_time"  1500000000000
-                             "services"    [{"name"            "feed"
-                                             "number_of_spans" 1}
-                                            {"name"            "orders"
-                                             "number_of_spans" 1}]}]}}
+                              {"trace_id"    "trace-2"
+                               "total_spans" 2
+                               "duration_ms" 2005
+                               "start_time"  1500000000000
+                               "services"    [{"name"            "feed"
+                                               "number_of_spans" 1}
+                                              {"name"            "orders"
+                                               "number_of_spans" 1}]}]}}
           response))


### PR DESCRIPTION
As of now cljfmt linter lacks vertical alignment on maps and bindings as discussed in https://github.com/weavejester/cljfmt/pull/77. So I decided to fork the original project and implement this feature. While this feature is not merged into the original project, I'm switching Atlas linter to this fork https://github.com/lucasmafra/cljfmt/.