### PR TITLE
Convert trace duration from microseconds to milliseconds

### DIFF
--- a/src/atlas/domain/sequence_diagram.clj
+++ b/src/atlas/domain/sequence_diagram.clj
@@ -9,7 +9,7 @@
 
 (defn- span->end-time [{:keys [start-time duration]}]
   (let [start-epoch (microseconds->epoch start-time)]
-    (time/plus start-epoch (time/millis duration))))
+    (time/plus start-epoch (time/micros duration))))
 
 (defn- match-tag?
   ([k] #(= k (:key %)))
@@ -44,7 +44,7 @@
   (fn [{:keys [span-id start-time duration] :as span}]
     {:id          span-id
      :start-time  (microseconds->epoch start-time)
-     :duration-ms duration
+     :duration-ms (/ duration 1000)
      :lifeline    (span->service-name span trace)}))
 
 (defn- find-child [span trace] (->> trace :spans (filter (child-of? span)) first))

--- a/test/atlas/domain/sequence_diagram_test.clj
+++ b/test/atlas/domain/sequence_diagram_test.clj
@@ -12,7 +12,7 @@
                 :process-id     :p1
                 :operation-name "http.in GET /api/orders/1"
                 :start-time     1500000000000000
-                :duration       1000
+                :duration       1000000
                 :references     []
                 :tags           [{:key   "span.kind"
                                   :type  "string"
@@ -29,7 +29,7 @@
                 :process-id     :p1
                 :operation-name "http.out GET /api/orders/1"
                 :start-time     1500000000100000
-                :duration       300
+                :duration       300000
                 :references     [{:ref-type :child-of
                                   :trace-id "1"
                                   :span-id  "1"}]
@@ -48,7 +48,7 @@
                 :process-id     :p2
                 :operation-name "http.in GET /api/orders/1"
                 :start-time     1500000000200000
-                :duration       100
+                :duration       100000
                 :references     [{:ref-type :child-of
                                   :trace-id "1"
                                   :span-id  "2"}]
@@ -66,7 +66,7 @@
                 :process-id     :p2
                 :operation-name "kafka.out PROCESS_ORDER"
                 :start-time     1500000000250000
-                :duration       50
+                :duration       50000
                 :references     [{:ref-type :child-of
                                   :trace-id "1"
                                   :span-id  "3"}]
@@ -81,7 +81,7 @@
                 :process-id     :p3
                 :operation-name "kafka.in PROCESS_ORDER"
                 :start-time     1500000000350000
-                :duration       50
+                :duration       50000
                 :references     [{:ref-type :child-of
                                   :trace-id "1"
                                   :span-id  "4"}]

--- a/test/flows/get_sequence_diagram.clj
+++ b/test/flows/get_sequence_diagram.clj
@@ -12,7 +12,7 @@
                           "processID"     "p1"
                           "operationName" "http.in GET /api/orders/1"
                           "startTime"     1500000000000000
-                          "duration"      1000
+                          "duration"      1000000
                           "references"    []
                           "tags"          [{"key"   "span.kind"
                                             "type"  "string"
@@ -29,7 +29,7 @@
                           "processID"     "p1"
                           "operationName" "http.out GET /api/orders/1"
                           "startTime"     1500000000100000
-                          "duration"      300
+                          "duration"      300000
                           "references"    [{"ref-type" "CHILD_OF"
                                             "traceID"  "1"
                                             "spanID"   "1"}]
@@ -48,7 +48,7 @@
                           "processID"     "p2"
                           "operationName" "http.in GET /api/orders/1"
                           "startTime"     1500000000200000
-                          "duration"      100
+                          "duration"      100000
                           "references"    [{"ref-type" "CHILD_OF"
                                             "traceID"  "1"
                                             "spanID"   "2"}]
@@ -66,7 +66,7 @@
                           "processID"     "p2"
                           "operationName" "kafka.out PROCESS_ORDER"
                           "startTime"     1500000000250000
-                          "duration"      50
+                          "duration"      50000
                           "references"    [{"ref-type" "CHILD_OF"
                                             "traceID"  "1"
                                             "spanID"   "3"}]
@@ -81,7 +81,7 @@
                           "processID"     "p2"
                           "operationName" "kafka.in PROCESS_ORDER"
                           "startTime"     1500000000350000
-                          "duration"      50
+                          "duration"      50000
                           "references"    [{"ref-type" "CHILD_OF"
                                             "traceID"  "1"
                                             "spanID"   "4"}]


### PR DESCRIPTION
We handle duration in milliseconds but Jaeger actually returns the duration in microseconds, so this commit converts trace duration correctly.