### PR TITLE
Make dev mode great again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clojure.java-time "0.3.2"]
-                 [lucasmafra/common-clj "1.5.0"]
+                 [lucasmafra/common-clj "1.5.3"]
                  [com.stuartsierra/component "0.4.0"]
                  [prismatic/schema "1.1.11"]]
 


### PR DESCRIPTION
This commit adds a mock http client to dev system so we can run Atlas locally using mocked traces located on `resources` directory.